### PR TITLE
Corrected missing "var" declaration

### DIFF
--- a/moment-datepicker/moment-datepicker.js
+++ b/moment-datepicker/moment-datepicker.js
@@ -293,7 +293,7 @@
             //TODO: use diff
             var nextMonthVal = moment(prevMonth).add(42, 'days').valueOf();
 
-            html = [];
+            var html = [];
             var clsName;
             //TODO: use diff
             while (prevMonth.valueOf() < nextMonthVal) {


### PR DESCRIPTION
A mising var declaration caused values to be saved to the global scope "html" variable instead of the local scope in the Datepicker.fill function. This bug is causing bundling and minification operations to fail.